### PR TITLE
fix: Prevent block_locator from ignoring newlines

### DIFF
--- a/lua/mcphub/native/neovim/files/edit_file/block_locator.lua
+++ b/lua/mcphub/native/neovim/files/edit_file/block_locator.lua
@@ -28,7 +28,7 @@ end
 ---@param file_content string Content of the target file
 ---@return LocatedBlock[] located_blocks Blocks with location information
 function BlockLocator:locate_all_blocks(parsed_blocks, file_content)
-    local file_lines = vim.split(file_content, "\n", { plain = true, trimempty = true })
+    local file_lines = vim.split(file_content, "\n", { plain = true, trimempty = false })
     local located_blocks = {}
     for _, parsed_block in ipairs(parsed_blocks) do
         if vim.trim(parsed_block.search_content) == "" then


### PR DESCRIPTION
## Description

block_locator was trimming empty lines from the beginning and end of files. This is more impactful when trying to append to a file that ends in a newline, which would include any text file adhering to the POSIX standard (ending in a newline).

Sometimes LLMs include the trailing newline in the search block, which causes the bound check to short-circuit in SearchEngine:_evaluate_position().

If you want to try to reproduce the Issue, I would suggest creating a simple file such as:

```text
Hello World

```

then telling an LLM to append something to the end of the file. I had this action fail with Claude Sonnet.

- [X] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README and/or relevant docs pages
- [X] I've run `make test` to ensure all tests pass
- [X] I've run `make format` to format the code
- [X] I've run `make docs` to update the vimdoc pages
